### PR TITLE
use set_form_data to send query string and a fix for ruby 1.9

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -63,7 +63,7 @@ module MCollective
         end
 
         query = transform_query(query, 'node')
-        JSON.parse(make_request('nodes', URI.encode(query.to_json))).map { |node| node['name'] }
+        JSON.parse(make_request('nodes', query.to_json)).map { |node| node['name'] }
       end
 
       # Retrieves the list hosts by querying the puppetdb resource endpoint,
@@ -83,7 +83,7 @@ module MCollective
 
         query = transform_query(query, 'klass')
 
-        JSON.parse(make_request('resources', URI.encode(query.to_json))).each do |result|
+        JSON.parse(make_request('resources', query.to_json)).each do |result|
           query_results[result['title']] << result['certname']
         end
 
@@ -114,10 +114,10 @@ module MCollective
       end
 
       def make_request(endpoint, query)
-        request = "/v2/%s" % endpoint
-        request += "?query=%s" % query if query
-
-        resp, data = @http.get(request, {'accept' => 'application/json'})
+        request = Net::HTTP::Get.new("/v2/%s" % endpoint, {'accept' => 'application/json'})
+        request.set_form_data({"query" => query}) if query
+        resp, data = @http.request(request)
+        data = resp.body if data.nil?
         raise 'Failed to make request to PuppetDB: %s: %s' % [resp.code, resp.message] unless resp.code == '200'
         data
       end


### PR DESCRIPTION
I was having trouble getting regular expression matching to work when using fact_filters with the rpcclient.  Before, it was sending the query using GET /v2/nodes?query=.... but puppetdb (I'm using 1.4) wants a GET with parameters in the body like a POST (apparently).

This patch fixes that, and as a by-product also sets the content-type field.  With the patch I can query with regular expressions as well as with straight matching filters.

The line
data = resp.body if data.nil?
is a fix for ruby 1.9 putting the data in the response body.  This should probably be part of a separate pull request?
