### PR TITLE
Fix Net::HTTP#get() for ruby 1.8+

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -117,9 +117,9 @@ module MCollective
         request = "/v2/%s" % endpoint
         request += "?query=%s" % query if query
 
-        resp, data = @http.get(request, {'accept' => 'application/json'})
+        resp = @http.get(request, {'accept' => 'application/json'})
         raise 'Failed to make request to PuppetDB: %s: %s' % [resp.code, resp.message] unless resp.code == '200'
-        data
+        resp.body
       end
 
       # Transforms a list of queries into single, complex query


### PR DESCRIPTION
The doc states that this function returned two values in version 1.1 (ruby 1.6).
http://ruby-doc.org/stdlib-1.8.7/libdoc/net/http/rdoc/Net/HTTP.html#method-i-get

It now returns only the HTTPResponse. We return the data from it.

This fixes mco find --dm=puppetdb.
