### PR TITLE
Only encode values, not the whole query string

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -76,11 +76,11 @@ module MCollective
 
         filter.each do |fact|
           op, value = translate_value(fact[:value], fact[:operator])
-          query << [op, ['fact', fact[:fact]], value]
+          query << [op, ['fact', URI.encode(fact[:fact])], URI.encode(value)]
         end
 
         query = transform_query(query, 'node')
-        JSON.parse(make_request('nodes', URI.encode(query.to_json))).map { |node| node['name'] }
+        JSON.parse(make_request('nodes', query.to_json)).map { |node| node['name'] }
       end
 
       # Retrieves the list hosts by querying the puppetdb resource endpoint,
@@ -95,12 +95,12 @@ module MCollective
 
         filter.each do |klass|
           op, value = translate_value(klass, '=')
-          query << ['and', ['=', 'type', 'Class'], [op, 'title', value]]
+          query << ['and', ['=', 'type', 'Class'], [op, 'title', URI.encode(value)]]
         end
 
         query = transform_query(query, 'klass')
 
-        JSON.parse(make_request('resources', URI.encode(query.to_json))).each do |result|
+        JSON.parse(make_request('resources', query.to_json)).each do |result|
           query_results[result['title']] << result['certname']
         end
 


### PR DESCRIPTION
The calls to `URI.encode` make the requests fail with an error 500:

```
The facts application failed to run, use -v for full error backtrace details: Failed to make request to PuppetDB: 500: Server Error
```
