### PR TITLE
Improve regex translation

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -176,11 +176,11 @@ module MCollective
 
       # Translates the op and value used in a query so that the
       # op matches the comparison characters used by PuppetDB.
-      # Regular expressions will have the '/' characters removed
-      # and the correct op value will be set
+      # Regular expressions will have the first and last '/'
+      # characters removed and the correct op value will be set
       def translate_value(value, op)
-        if value =~ /^\//
-          value = value.gsub('/', '')
+        if value =~ /^\/.*\/$/
+          value = value.gsub(/^\/|\/$/, '')
           op = '~'
         end
 


### PR DESCRIPTION
 In our infrastructure, we happen to have facts which contain '/' characters. Currently, the plugin doesn't allow us to query for those facts using regex, as all the '/' characteres are removed from the query.

This merge request changes that part of the code to remove only the slashes which enclose the value of the fact.