### PR TITLE
remove "WARN -- : HTTPI executes HTTP GET using the curb adapter" messag...

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -49,6 +49,7 @@ module MCollective
         req = HTTPI::Request.new()
         req.auth.ssl.verify_mode = :none
         req.auth.gssnegotiate
+        HTTPI.log = false
         HTTPI.adapter = :curb
         req
       end


### PR DESCRIPTION
Remove unnecessary warning messages from HTTPI