### PR TITLE
Make PuppetDB API version configurable and with v3 as default

### DIFF
--- a/spec/util/puppetdb_discovery_spec.rb
+++ b/spec/util/puppetdb_discovery_spec.rb
@@ -29,6 +29,7 @@ module MCollective
         result.config[:ssl_ca].should == nil
         result.config[:ssl_cert].should == nil
         result.config[:ssl_key].should == nil
+        result.config[:api_version].should == '2'
       end
 
         it 'should set custom configuration values and create an http object' do
@@ -38,7 +39,9 @@ module MCollective
                            'discovery.puppetdb.port' => '8081',
                            'discovery.puppetdb.ssl_ca' => 'rspec/ca.pem',
                            'discovery.puppetdb.ssl_cert' => 'rspec/host.your.com.cert.pem',
-                           'discovery.puppetdb.ssl_private_key' => 'rspec/host.your.com.pem' }
+                           'discovery.puppetdb.ssl_private_key' => 'rspec/host.your.com.pem',
+                           'discovery.puppetdb.api_version' => '4',
+                         }
 
           config.stubs(:pluginconf).returns(pluginconf)
 
@@ -49,6 +52,7 @@ module MCollective
           result.config[:ssl_ca].should == 'rspec/ca.pem'
           result.config[:ssl_cert].should == 'rspec/host.your.com.cert.pem'
           result.config[:ssl_key].should == 'rspec/host.your.com.pem'
+          result.config[:api_version].should == '4'
         end
       end
 

--- a/spec/util/puppetdb_discovery_spec.rb
+++ b/spec/util/puppetdb_discovery_spec.rb
@@ -29,7 +29,7 @@ module MCollective
         result.config[:ssl_ca].should == nil
         result.config[:ssl_cert].should == nil
         result.config[:ssl_key].should == nil
-        result.config[:api_version].should == '2'
+        result.config[:api_version].should == '3'
       end
 
         it 'should set custom configuration values and create an http object' do

--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -14,7 +14,7 @@ module MCollective
         @config[:ssl_ca] = config.pluginconf.fetch('discovery.puppetdb.ssl_ca', nil)
         @config[:ssl_cert] = config.pluginconf.fetch('discovery.puppetdb.ssl_cert', nil)
         @config[:ssl_key] = config.pluginconf.fetch('discovery.puppetdb.ssl_private_key', nil)
-        @config[:api_version] = config.pluginconf.fetch('discovery.puppetdb.api_version', '2')
+        @config[:api_version] = config.pluginconf.fetch('discovery.puppetdb.api_version', '3')
         @http = create_http
       end
 

--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -14,6 +14,7 @@ module MCollective
         @config[:ssl_ca] = config.pluginconf.fetch('discovery.puppetdb.ssl_ca', nil)
         @config[:ssl_cert] = config.pluginconf.fetch('discovery.puppetdb.ssl_cert', nil)
         @config[:ssl_key] = config.pluginconf.fetch('discovery.puppetdb.ssl_private_key', nil)
+        @config[:api_version] = config.pluginconf.fetch('discovery.puppetdb.api_version', '2')
         @http = create_http
       end
 
@@ -142,7 +143,7 @@ module MCollective
       end
 
       def make_request_normal(endpoint, query)
-        request = Net::HTTP::Get.new("/v2/%s" % endpoint, {'accept' => 'application/json'})
+        request = Net::HTTP::Get.new("/v#{@config[:api_version]}/%s" % endpoint, {'accept' => 'application/json'})
         request.set_form_data({"query" => query}) if query
         resp, data = @http.request(request)
         data = resp.body if data.nil?
@@ -153,7 +154,7 @@ module MCollective
       # With HTTPI and curb for Kerberos support 
       def make_request_krb(endpoint, query)
         require 'cgi'
-        @http.url = "https://#{@config[:host]}:#{@config[:port]}/v2/#{endpoint}" + (query ? "?query=#{CGI.escape(query)}" : '')
+        @http.url = "https://#{@config[:host]}:#{@config[:port]}/v#{@config[:api_version]}/#{endpoint}" + (query ? "?query=#{CGI.escape(query)}" : '')
         resp = HTTPI.get(@http)
         raise 'Failed to make request to PuppetDB: code %s' % [resp.code] if resp.error?
         resp.raw_body


### PR DESCRIPTION
As v3 is the recommended API version as today.

We are targeting to move to v4 in the near future, but, as the JSON response of the nodes endpoint has changed considerably, this will require to modify the parsing being done by the plugin.