### PR TITLE
add support for discovery options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The PuppetDB discovery plugin can be activated either by specifying it in your c
 or by using it on the cli
 
     % mco rpc rpcutil ping --dm puppetdb -F operatingsytem=CentOS
+    % mco rpc rpcutil ping --dm puppetdb --do '["in", "certname", ["extract", "certname", ["select-resources", ["and", ["=", "type", "Apache::Vhost"], ["=", "title", "myvhost"]]]]]'
+
 
 Other configuration settings that can be tuned depending our your PuppetDB installation are :
 
@@ -61,4 +63,12 @@ Connect to a remote PuppetDB server using Kerberos
      plugin.discovery.puppetdb.ssl_ca = /etc/mcollective/puppetdb/ca.pem
      plugin.discovery.puppetdb.ssl_cert = /etc/mcollective/puppetdb/host1.your.com.cert.pem
      plugin.discovery.puppetdb.ssl_private_key = /etc/mcollective/puppetdb/host1.your.com.pem
+
+###Example client implementations
+
+Discover nodes whith a custom puppetdb query
+
+     mc.discovery_method  = "puppetdb"
+     mc.discovery_options = ["in", "certname", ["extract", "certname", ["select-resources", ["and", ["=", "type", "Apache::Vhost"], ["=", "title", "myvhost"]]]]].inspect
+
 

--- a/discovery/puppetdb.rb
+++ b/discovery/puppetdb.rb
@@ -4,7 +4,8 @@ module MCollective
 
       def self.discover(filter, timeout, limit = 0, client = nil)
         require 'mcollective/util/puppetdb_discovery'
-        Util::PuppetdbDiscovery.new(Config.instance).discover(filter)
+        options = client.options[:discovery_options]
+        Util::PuppetdbDiscovery.new(Config.instance).discover(filter,options)
       end
     end
   end

--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -18,12 +18,12 @@ module MCollective
         @http = create_http
       end
 
-      def discover(filter)
+      def discover(filter,query=nil)
         found = []
 
         #if no filters are to be applied, we fetch all the nodes registered in puppetdb
         if filter['fact'].empty? && filter['cf_class'].empty? && filter['identity'].empty?
-          found = node_search
+          found = node_search(query)
         else
           found << fact_search(filter['fact']) unless filter['fact'].empty?
           found << class_search(filter['cf_class']) unless filter['cf_class'].empty?
@@ -131,9 +131,9 @@ module MCollective
         hosts
       end
 
-      # Looks up all the nodes registered in puppetdb without applying any filters
-      def node_search
-        JSON.parse(make_request('nodes', nil)).map { |node| node['name'] }
+      # Looks up all the nodes registered in puppetdb with an optional filter
+      def node_search(query=nil)
+        JSON.parse(make_request('nodes', query)).map { |node| node['name'] }
       end
 
       def make_request(endpoint, query)


### PR DESCRIPTION
Gives you the possibility to provide a custom PuppetDB query for more sophisticated node discovery
i.e. search for all nodes where a specific Apache::Vhost is configured
Unfortunately i have no knowledge of rspec, therefore i did not provide any tests with this pull request