### PR TITLE
collective_fact option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Other configuration settings that can be tuned depending our your PuppetDB insta
  * discovery.puppetdb.port - The unencrpyted HTTP __or__ SSL port your PuppetDB server listens on. Defaults to 8080
  * discovery.puppetdb.use_ssl - Enable using SSL. Defaults to false
  * discovery.puppetdb.use_krb - Enable using Kerberos. Defaults to false
+ * discovery.puppetdb.collective_fact - Define a fact to filter all queries with the value of the collective thus avoiding to fetch all the nodes registered in puppetdb each time. Defaults to false
 
 The following settings should only be configured if you are using SSL communications. They will all be disabled by default.
 
@@ -61,4 +62,10 @@ Connect to a remote PuppetDB server using Kerberos
      plugin.discovery.puppetdb.ssl_ca = /etc/mcollective/puppetdb/ca.pem
      plugin.discovery.puppetdb.ssl_cert = /etc/mcollective/puppetdb/host1.your.com.cert.pem
      plugin.discovery.puppetdb.ssl_private_key = /etc/mcollective/puppetdb/host1.your.com.pem
+
+Filter all queries using the hostgroup_0 fact
+
+     plugin.discovery.puppetdb.collective_fact = hostgroup_0
+
+The effect would be equivalent to -F hostgroup_0=<collective> in the command line
 

--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -15,12 +15,19 @@ module MCollective
         @config[:ssl_cert] = config.pluginconf.fetch('discovery.puppetdb.ssl_cert', nil)
         @config[:ssl_key] = config.pluginconf.fetch('discovery.puppetdb.ssl_private_key', nil)
         @config[:api_version] = config.pluginconf.fetch('discovery.puppetdb.api_version', '3')
+        @config[:collective_fact] = config.pluginconf.fetch('discovery.puppetdb.collective_fact', nil)
         @http = create_http
       end
 
       def discover(filter)
         found = []
 
+        unless @config[:collective_fact].nil?
+            unless filter.has_key?('fact')
+                filter['fact'] = Array.new
+            end
+            filter['fact'].push({:fact=>@config[:collective_fact], :value=>filter['collective'], :operator=>"="})
+        end
         #if no filters are to be applied, we fetch all the nodes registered in puppetdb
         if filter['fact'].empty? && filter['cf_class'].empty? && filter['identity'].empty?
           found = node_search


### PR DESCRIPTION
Please consider the following PR.

It implements the collective_fact option allowing to define a fact to filter all requests with the value of the collective thus making sure that we avoid fetching all nodes defined in Puppetdb for trivial queries.

```
                                     thanks, Best regards  ...Ignacio...
```
