### PR TITLE
Dereferences alias for hostname to avoid problem when rdns is false in kerberos configuration

### DIFF
--- a/util/puppetdb_discovery.rb
+++ b/util/puppetdb_discovery.rb
@@ -152,7 +152,12 @@ module MCollective
       end
 
       def make_request_normal(endpoint, query)
-        request = Net::HTTP::Get.new("/v#{@config[:api_version]}/%s" % endpoint, {'accept' => 'application/json'})
+        if @config[:api_version] >= '4'
+          request = Net::HTTP::Get.new("/pdb/query/v#{@config[:api_version]}/%s" % endpoint, {'accept' => 'application/json'})
+        else
+          request = Net::HTTP::Get.new("/v#{@config[:api_version]}/%s" % endpoint, {'accept' => 'application/json'})
+        end
+
         request.set_form_data({"query" => query}) if query
         resp, data = @http.request(request)
         data = resp.body if data.nil?
@@ -163,10 +168,23 @@ module MCollective
       # With HTTPI and curb for Kerberos support 
       def make_request_krb(endpoint, query)
         require 'cgi'
-        @http.url = "https://#{@config[:host]}:#{@config[:port]}/v#{@config[:api_version]}/#{endpoint}" + (query ? "?query=#{CGI.escape(query)}" : '')
+        fqhostname = deref(@config[:host])
+        if @config[:api_version] >= '4'
+          @http.url = "https://#{fqhostname}:#{@config[:port]}/pdb/query/v#{@config[:api_version]}/#{endpoint}" + (query ? "?query=#{CGI.escape(query)}" : '')
+        else
+          @http.url = "https://#{fqhostname}:#{@config[:port]}/v#{@config[:api_version]}/#{endpoint}" + (query ? "?query=#{CGI.escape(query)}" : '')
+        end
+
         resp = HTTPI.get(@http)
         raise 'Failed to make request to PuppetDB: code %s' % [resp.code] if resp.error?
         resp.raw_body
+      end
+
+      # Dereferences LB alias to avoid problem when rdns is false in /etc/krb5.conf
+      def deref(lbalias)
+        require 'resolv'
+        chosen_ip = Resolv.getaddresses(lbalias).sample
+        Resolv.getnames(chosen_ip).first
       end
 
       # Transforms a list of queries into single, complex query


### PR DESCRIPTION
Dereferences alias for hostname to avoid problem when rdns is false in /etc/krb5.conf 
+ support api version >=4